### PR TITLE
Add more properties

### DIFF
--- a/sample.config.json
+++ b/sample.config.json
@@ -1,23 +1,78 @@
 {
     "properties": {
         "P698": "PubMed ID",
+        "P356": "DOI",
+        "P212": "ISBN",
+        "P957": "ISBN",
         "P854": "reference url"
     },
-    "zoteroProperties": {
+    "zoteroProperties":  {
+        "abstractNote": null,
         "accessDate": "P813",
+        "applicationNumber": null,
+        "archive": null,
+        "archiveLocation": null,
+        "artworkSize": null,
+        "assignee": null,
+        "callNumber": null,
+        "code": null,
+        "committee": null,
+        "company": null,
+        "conferenceName": null,
+        "country": null,
+        "court": null,
         "date": "P577",
-        "title": "P1476"
+        "DOI": "P356",
+        "edition": null,
+        "extra": null,
+        "filingDate": null,
+        "firstPage": null,
+        "genre": null,
+        "history": null,
+        "institution": null,
+        "ISBN": "P212",
+        "ISSN": "P236",
+        "issue": "P433",
+        "issuingAuthority": null,
+        "journalAbbreviation": null,
+        "language": null,
+        "legalStatus": null,
+        "legislativeBody": null,
+        "libraryCatalog": null,
+        "medium": null,
+        "meetingName": null,
+        "number": null,
+        "numberOfVolumes": null,
+        "numPages": "P1104",
+        "oclc": null,
+        "pages": "P304",
+        "place": null,
+        "PMCID": "P932",
+        "PMID": "P698",
+        "priorityNumbers": null,
+        "programmingLanguage": null,
+        "publicationTitle": null,
+        "publisher": null,
+        "references": null,
+        "reporter": null,
+        "rights": null,
+        "runningTime": null,
+        "scale": null,
+        "section": null,
+        "series": null,
+        "seriesNumber": null,
+        "seriesText": null,
+        "seriesTitle": null,
+        "session": null,
+        "shortTitle": null,
+        "system": null,
+        "title": "P1476",
+        "url": "P2699",
+        "version": null,
+        "volume": "P478"
     },
-    "refTypes": {
-        "newspaperArticle": {
-            "title": {
-                "id": "P1476",
-                "valuetype": "monolingualtext"
-            },
-            "url": {
-                "id": "P854",
-                "valuetype": "string"
-            }
-        }
+    "queryProperties": {
+        "DOI": "P356",
+        "ISSN": "P236"
     }
 }

--- a/src/CitoidClient.js
+++ b/src/CitoidClient.js
@@ -9,7 +9,7 @@ function CitoidClient() {
 CitoidClient.prototype.search = function( value ) {
     var dfd = $.Deferred(),
         baseUrl = 'https://en.wikipedia.org/api/rest_v1/data/citation',
-        format = 'mediawiki',
+        format = 'mediawiki-basefields',
         url = baseUrl + '/' + format + '/' + encodeURIComponent(value);
     $.ajax( {
         method: 'GET',


### PR DESCRIPTION
* Change citoid format from mediawiki to mediawiki-basefields;
this format has fewer total properties.
* Add complete list of mediawiki-basefields properties
to the sample config, most with null value, and fill in a few.
* Add function for adding snaks with a String datavalue
* In CiteToolReferenceEditor, add the ability to add several
string properties using some of the added keys in zoteroProperties
config.
* In the sample config, remove unused 'refTypes' key.
* In the sample config, add 'queryProperties' key; this is currently
used by some WIP code. Comment out the code that uses this key as
it still doesn't work though.

If you want to test this on Wikidata proper, I've got it in my common.js: 
```
mw.loader.using(['wikibase'], function() {
	$.getScript( 'https://www.wikidata.org/w/index.php?title=User:Mvolz_(WMF)/CiteTool.js&action=raw&ctype=text/javascript', function() {
		var citeTool = new wb.CiteTool( 'https://www.wikidata.org/w/index.php?title=User:Mvolz_(WMF)/CiteProperties.json&action=raw&ctype=application/json' );
		citeTool.init();
	});
});
```